### PR TITLE
script to handle MFA and .aws/credentials

### DIFF
--- a/00-dev-environment/st-aws-token
+++ b/00-dev-environment/st-aws-token
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+## We can accept this as an argument up-front... if we dont' get it here
+## we'll ask for it later.
+MFA_TOKEN="$1"; shift
+
+_FNAME_BASE="aws_mfa_auth"
+_FNAME="${_FNAME_BASE}_$(date "+%s")"
+_TMP_FILE="/root/.aws/$_FNAME"
+_LOCAL_FILE="$HOME/.aws/$_FNAME"
+AWS_CLI_IMAGE_NAME="amazon/aws-cli"
+AWS_CLI_VERSION="2.2.11"
+AWS_CLI_IMAGE="$AWS_CLI_IMAGE_NAME:$AWS_CLI_VERSION"
+AWS_DEFAULT_REGION="us-east-2"
+
+CREDS_FILES=($(find $HOME/.aws -type f -name 'credentials-*'))
+SELECTED_ACCOUNT=""
+
+[[ "${#CREDS_FILES[@]}" -eq 0 ]] && {
+    echo "Could not find any 'credentials-*' files in $HOME/.aws" >&2 && exit 1
+}
+
+function mangle_filename() {
+    local abs_file="$1"; shift
+    [[ -z "$abs_file" ]] && echo "ERROR: mangle_filename requires an absolute file as an argument" >&2 && return 1
+
+    echo "$(basename "$abs_file")" | sed 's/credentials-//' && return 0
+    return 1
+}
+
+## dig values out of the creds file by key
+function get_config_val() {
+    local key="$1"; shift
+    local file="${1:-$ORIG_CREDS}"; shift
+
+    val="$(awk -F= ' $1 ~/'$key'/ { print $2 } ' $file | tr -d '"' | xargs)"
+    echo "$val"
+    [[ -n "$val" ]] && return 0
+    return 1
+}
+
+[[ "${#CREDS_FILES[@]}" -eq 1 ]] && {
+    ORIG_CREDS="${CREDS_FILES[@]}"
+    echo "Using: $ORIG_CREDS"
+} || {
+    counter=1
+    echo
+    for f in ${CREDS_FILES[@]}
+    do
+        display="Account: $(mangle_filename "$f")"
+        echo "  [$counter] $display"
+        ((counter++))
+    done
+    echo
+    while [[ "$ORIG_CREDS" == "" ]]
+    do
+        read -p "Enter the number for the credentials file to use: " num
+        ## subtract one to line up with 0-based index
+        ((num--))
+        ORIG_CREDS="${CREDS_FILES[num]}"
+        [[ -z "$ORIG_CREDS" ]] && echo "ERROR: You must chose a valid option." >&2
+    done
+}
+
+SELECTED_ACCOUNT="$(mangle_filename "$ORIG_CREDS")"
+echo " --> Inferred account $SELECTED_ACCOUNT from $(basename "$ORIG_CREDS")"
+
+## can't do much without this
+while [[ -z "$MFA_TOKEN" ]]
+do
+    read -p "Enter MFA Token: " MFA_TOKEN
+    [[ -z "$MFA_TOKEN" ]] && echo "ERROR: You must enter a token..." >&2
+done
+
+## Pull up some docker to run the aws-cli stuff
+docker run \
+    --rm -it \
+    -v $HOME/.aws:/root/.aws \
+    -e AWS_ACCESS_KEY_ID="$(get_config_val "aws_access_key_id")" \
+    -e AWS_SECRET_ACCESS_KEY="$(get_config_val "aws_secret_access_key")" \
+    -e AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION" \
+    --entrypoint bash \
+    $AWS_CLI_IMAGE \
+    -lc "aws sts get-session-token \
+        --serial-number arn:aws:iam::324320755747:mfa/$SELECTED_ACCOUNT \
+        --token-code $MFA_TOKEN > $_TMP_FILE"
+
+## we look ok so far ?
+[[ "$?" -ne 0 ]] || [[ ! -f "$_LOCAL_FILE" ]] && {
+    echo "ERROR: Unable to get session token" >&2 && exit 1
+}
+
+key_id="$(jq -r '.Credentials.AccessKeyId' $_LOCAL_FILE)"
+secret="$(jq -r '.Credentials.SecretAccessKey' $_LOCAL_FILE)"
+token="$(jq  -r '.Credentials.SessionToken' $_LOCAL_FILE)"
+expiration="$(jq  -r '.Credentials.Expiration' $_LOCAL_FILE)"
+
+## if we don't have these something is amiss.
+[[ -n "$key_id" ]] && [[ -n "$secret" ]] && [[ -n "$token" ]] || {
+    echo "ERROR: Unable to proceed.
+    key_id: $key_id
+    secret: $secret
+    token: $token"
+    exit 1
+}
+
+## These are no longer needed...
+rm $HOME/.aws/${_FNAME_BASE}*
+
+## Write our creds file
+echo "[default]
+output = json
+region = $AWS_DEFAULT_REGION
+aws_access_key_id = $key_id
+aws_secret_access_key = $secret
+aws_session_token = $token
+" > $HOME/.aws/credentials
+
+echo "Expires: $expiration"
+
+## Verify we are who we think we are... 
+docker run \
+    --rm -it \
+    -v $HOME/.aws:/root/.aws \
+    $AWS_CLI_IMAGE \
+        sts get-caller-identity
+
+exit $?
+    


### PR DESCRIPTION
## Identify the Bug
No bug

## Description of the Change
Script to address CLI access and MFA with multiple files. Follow me:
Each `credentials-*` file below is suffixed with the account name (i.e `credentials-accountname`). The account name is used in the ARN when calling AWS.
```
√ ~ % ls -al .aws                                                                                                             
total 32
drwxr-xr-x   6 kyle.shenk  staff  192 Jun 15 14:17 .
drwxr-xr-x+ 30 kyle.shenk  staff  960 Jun 15 19:48 ..
-rw-------   1 kyle.shenk  staff   10 Jun 14 09:14 config
-rw-r--r--   1 kyle.shenk  staff  839 Jun 15 14:17 credentials
-rw-r--r--   1 kyle.shenk  staff  150 Jun 14 14:20 credentials-kyle.shenk
-rw-r--r--   1 kyle.shenk  staff  149 Jun 15 14:12 credentials-kyle.shenk.labs
```
```
√ ~ % st-aws-token 

  [1] Account: kyle.shenk
  [2] Account: kyle.shenk.labs

Enter the number for the credentials file to use: 2
 --> Inferred account kyle.shenk.labs from credentials-kyle.shenk.labs
Enter MFA Token: 388275
Expires: 2021-06-16T06:17:56+00:00
{
    "UserId": "AIDEWYBFJSKAUHKAGFUB",
    "Account": "324320755747",
    "Arn": "arn:aws:iam::324320755747:user/kyle.shenk.labs"
}
```

## Alternate Designs
N/A

## Possible Drawbacks
 - This doesn't honor any other configuration(s) elsewhere. 
 -  We **overwrite** `~/.aws/credentials` on each successful run
 - This is a rough draft... ymmv

## Verification Process
Options that "make sense" work - negative numbers in options blow errors but continue without issues. Alpha characters not tested.... etc.

## Release Notes
Adds a script to handle MFA enabled accounts